### PR TITLE
julia: copy collected suitesparse libraries into julia's private lib

### DIFF
--- a/julia.rb
+++ b/julia.rb
@@ -174,13 +174,16 @@ class Julia < Formula
     
     # Install!
     system "make", "install", *build_opts
+    ['amd', 'cholmod', 'colamd', 'spqr', 'umfpack'].each do |sslib|
+      cp "usr/lib/lib#{sslib}.dylib", "#{lib}/julia"
+    end
 
     # Add in rpath's into the julia executables so that they can find the homebrew lib folder,
     # as well as any keg-only libraries that they need.
     rpaths = []
 
     # Only add in openblas if we're not using accelerate
-    rpathFormulae = [arpack, suitesparse]
+    rpathFormulae = [arpack]
     rpathFormulae << openblas if !build.include? 'with-accelerate'
 
     # Add in each formula to the rpaths list


### PR DESCRIPTION
If we repackage the system suitesparse libraries, we'll need to copy them during the install manually, as the default for USE_SYSTEM_SUITESPARSE=1 does not copy them.
