### PR TITLE
Fix silly warning on 64bit platforms

### DIFF
--- a/julia.rb
+++ b/julia.rb
@@ -76,7 +76,7 @@ class Julia < Formula
 
     # First, check to make sure we don't have impossible options passed in
     if build.include? "64bit"
-      if Hardware.is_64_bit?
+      if !Hardware.is_64_bit?
         opoo "Cannot compile 64-bit on a 32-bit architecture!"
       end
       if build.include? "with-accelerate"


### PR DESCRIPTION
The flag warned that it couldn't compile 64bit on a 64bit platform.
Now it warns that it can't compile 64bit on a 32bit platform as
intended.
