### PR TITLE
Migrate to more current features of Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A small tap for the [Homebrew project](http://mxcl.github.com/homebrew/) to inst
 ```bash
 $ brew update
 $ brew install gfortran
-$ brew tap homebrew/homebrew-versions
 $ brew tap staticfloat/julia
 $ brew install julia
 ```

--- a/julia.rb
+++ b/julia.rb
@@ -27,7 +27,7 @@ class Julia < Formula
 
   stable do
     url 'https://github.com/JuliaLang/julia.git', :using => GitNoDepthDownloadStrategy, :tag => 'v0.2.0'
-    depends_on "llvm33"
+    depends_on "homebrew/versions/llvm33"
   end
 
   head do


### PR DESCRIPTION
Hi, this pull request migrates the Julia formula to use more current features of Homebrew:
- Use resources instead of subformulae. Resources are downloaded when you `brew fetch` a formula, and have a few other nifty features, though I've just demonstrated basic usage here.
- Use blocks to declare stable and head specific dependencies. This is the preferred way to handle stable/devel/head dependencies, as using conditionals presents a number of problems and can result in the wrong set of dependencies being selected in certain situations. These blocks currently support dependencies, options, and resources, and other DSL methods (fails_with in particular) will be supported eventually.
- Use `Formula["name"]` instead of `Formula.factory("name")`. This is more of a stylistic thing, but `factory` will probably become an audit warning in the future.
-  Fully specify the dependency on `homebrew/versions/llvm33`, which will cause the installer to tap `homebrew-versions` automatically.

I am sending this PR because I want people to adopt these practices, and because I've been working on some improvements to dependency and option handling, and I want the way people are using existing features, or working around them, to guide future development. 
