### PR TITLE
Fix `brew audit` warnings

### DIFF
--- a/arpack-julia.rb
+++ b/arpack-julia.rb
@@ -6,21 +6,18 @@ class ArpackJulia < Formula
   mirror 'http://d304tytmzqn1fl.cloudfront.net/arpack-ng-3.1.3.tar.gz'
   sha1 'c1ac96663916a4e11618e9557636ba1bd1a7b556'
 
-  depends_on 'open-mpi'
-  depends_on 'openblas-julia' if !build.include? 'with-accelerate'
-  
+  depends_on :fortran
+  depends_on :mpi => :f77
+  depends_on 'openblas-julia' if build.without? 'accelerate'
+
   keg_only "Conflicts with arpack"
 
   option 'with-accelerate', 'Compile against Accelerate/vecLib instead of OpenBLAS'
 
   def install
-    ENV.fortran
-
-    # Include MPIF77, as the arpack-ng build process doesn't autodetect properly
-    ENV['MPIF77'] = 'mpif77'
 
     configure_args = ["--disable-dependency-tracking", "--prefix=#{prefix}", "--enable-shared"]
-    if build.include? "with-accelerate"
+    if build.with? "accelerate"
       configure_args << "--with-blas=-framework vecLib -lblas"
       configure_args << "--with-lapack=-framework vecLib -lblas"
     else

--- a/arpack64-julia.rb
+++ b/arpack64-julia.rb
@@ -6,16 +6,14 @@ class Arpack64Julia < Formula
   mirror 'http://d304tytmzqn1fl.cloudfront.net/arpack-ng-3.1.3.tar.gz'
   sha1 'c1ac96663916a4e11618e9557636ba1bd1a7b556'
 
-  depends_on 'open-mpi'
+  depends_on :fortran
+  depends_on :mpi => :f77
   depends_on 'openblas64-julia'
 
   keg_only "Conflicts with arpack"
 
   def install
-    ENV.fortran
 
-    # Include MPIF77, as the arpack-ng build process doesn't autodetect properly
-    ENV['MPIF77'] = 'mpif77'
     if !ENV.has_key?('FFLAGS')
         ENV['FFLAGS'] = ''
     end

--- a/openblas-julia.rb
+++ b/openblas-julia.rb
@@ -8,14 +8,14 @@ class OpenblasJulia < Formula
   sha1 'd012ebc2b8dcd3e95f667dff08318a81479a47c3'
   head "https://github.com/xianyi/OpenBLAS.git", :branch => "develop"
 
+  depends_on :fortran
+
   # OS X provides the Accelerate.framework, which is a BLAS/LAPACK impl.
   keg_only :provided_by_osx
 
   option "target=", "Manually override the CPU type detection and provide your own TARGET make variable"
 
   def install
-    ENV.fortran
-
     # Must call in two steps
     if ARGV.value('target')
       system "make", "FC=#{ENV['FC']}", "TARGET=#{ARGV.value('target')}"

--- a/openblas64-julia.rb
+++ b/openblas64-julia.rb
@@ -8,14 +8,14 @@ class Openblas64Julia < Formula
   sha1 'd012ebc2b8dcd3e95f667dff08318a81479a47c3'
   head "https://github.com/xianyi/OpenBLAS.git", :branch => "develop"
 
+  depends_on :fortran
+
   # OS X provides the Accelerate.framework, which is a BLAS/LAPACK impl.
   keg_only :provided_by_osx
 
   option "target=", "Manually override the CPU type detection and provide your own TARGET make variable"
 
   def install
-    ENV.fortran
-
     # Must call in two steps
     if ARGV.value('target')
       system "make", "FC=#{ENV['FC']}", "INTERFACE64=1", "TARGET=#{ARGV.value('target')}"

--- a/suite-sparse-julia.rb
+++ b/suite-sparse-julia.rb
@@ -5,13 +5,13 @@ class SuiteSparseJulia < Formula
   mirror 'http://d304tytmzqn1fl.cloudfront.net/SuiteSparse-4.2.1.tar.gz'
   sha1 '2fec3bf93314bd14cbb7470c0a2c294988096ed6'
 
-  depends_on "tbb" if build.include? 'with-tbb'
-  depends_on "metis" if build.include? 'with-metis'
-  depends_on "openblas-julia" if !build.include? 'with-accelerate'
+  depends_on "tbb" => :optional
+  depends_on "metis" => :optional
+  depends_on "openblas-julia" if build.without? 'accelerate'
 
   option "with-metis", "Compile in metis libraries"
   option 'with-accelerate', 'Compile against Accelerate/vecLib instead of OpenBLAS'
-  
+
   keg_only "Conflicts with suite-sparse"
 
   def install
@@ -20,24 +20,24 @@ class SuiteSparseJulia < Formula
 
     inreplace 'SuiteSparse_config/SuiteSparse_config.mk' do |s|
       # Put in the proper libraries
-      s.change_make_var! "BLAS", "-lopenblas" if !build.include? 'with-accelerate'
-      s.change_make_var! "BLAS", "-Wl,-framework -Wl,Accelerate" if build.include? 'with-accelerate'
+      s.change_make_var! "BLAS", "-lopenblas" if build.without? 'accelerate'
+      s.change_make_var! "BLAS", "-Wl,-framework -Wl,Accelerate" if build.with? 'accelerate'
       s.change_make_var! "LAPACK", "$(BLAS)"
 
-      if build.include? "with-tbb"
+      if build.with? "tbb"
         s.change_make_var! "SPQR_CONFIG", "-DHAVE_TBB"
         s.change_make_var! "TBB", "-ltbb"
       end
 
-      if build.include? "with-metis"
+      if build.with? "metis"
         s.remove_make_var! "METIS_PATH"
-        s.change_make_var! "METIS", Formula.factory("metis").lib + "libmetis.a"
+        s.change_make_var! "METIS", Formula["metis"].lib + "libmetis.a"
       end
 
       # Installation
       s.change_make_var! "INSTALL_LIB", lib
       s.change_make_var! "INSTALL_INCLUDE", include
-      
+
       s.change_make_var! "SPQR_CONFIG", "-DNCAMD -DNPARTITION"
       s.change_make_var! "CHOLMOD_CONFIG", "-DNCAMD -DNPARTITION"
     end

--- a/suite-sparse64-julia.rb
+++ b/suite-sparse64-julia.rb
@@ -5,8 +5,8 @@ class SuiteSparse64Julia < Formula
   mirror 'http://d304tytmzqn1fl.cloudfront.net/SuiteSparse-4.2.1.tar.gz'
   sha1 '2fec3bf93314bd14cbb7470c0a2c294988096ed6'
 
-  depends_on "tbb" if build.include? 'with-tbb'
-  depends_on "metis" if build.include? 'with-metis'
+  depends_on "tbb" => :optional
+  depends_on "metis" => :optional
   depends_on "openblas64-julia"
 
   option "with-metis", "Compile in metis libraries"
@@ -22,20 +22,20 @@ class SuiteSparse64Julia < Formula
       s.change_make_var! "BLAS", "-lopenblas"
       s.change_make_var! "LAPACK", "$(BLAS)"
 
-      if build.include? "with-tbb"
+      if build.with? "tbb"
         s.change_make_var! "SPQR_CONFIG", "-DHAVE_TBB"
         s.change_make_var! "TBB", "-ltbb"
       end
 
-      if build.include? "with-metis"
+      if build.with? "metis"
         s.remove_make_var! "METIS_PATH"
-        s.change_make_var! "METIS", Formula.factory("metis").lib + "libmetis.a"
+        s.change_make_var! "METIS", Formula["metis"].lib + "libmetis.a"
       end
 
       # Installation
       s.change_make_var! "INSTALL_LIB", lib
       s.change_make_var! "INSTALL_INCLUDE", include
-      
+
       s.change_make_var! "SPQR_CONFIG", "-DNCAMD -DNPARTITION"
     end
 


### PR DESCRIPTION
This is a follow up to #71 specifically addressing the current warnings given by `brew audit`. These are caused by some softly-deprecated methods and style conventions, and the changes are restricted to those suggested by audit. The formulae should work the same.
