### PR TITLE
Include more dependencies for removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ brew test -v --HEAD julia
 If compilation of Julia fails, or the tests fail, you may have to remove these dependencies and recompile:
 
 ```bash
-$ brew rm julia arpack-julia suite-sparse-julia openblas-julia
+$ brew rm julia arpack-julia suite-sparse-julia openblas-julia cloog018-julia gmp4-julia isl011-julia llvm33-julia
 $ brew install -v --HEAD julia && brew test -v --HEAD julia
 ```
 


### PR DESCRIPTION
Good for copying and pasting on the command line. As more dependencies are included, a simpler command may be needed.
