### PR TITLE
Instructions for rebuilding with userimg.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ require("JuMP")
 By default, the `userimg.jl` file does not exist, but you can provide it yourself, using the `--userimg` option (using `reinstall` rather than `install` if Julia is already installed):
 
 ```bash
-$ brew install julia --build-from-source --userimg=$HOME/julia/myuserimg.jl
+$ brew install julia --userimg=$HOME/julia/myuserimg.jl
 ```
 
 The file will then be copied and renamed before the main build, potentially leading to significant speedups when loading the specified modules.


### PR DESCRIPTION
Added specific instructions to `README.jl` about using `reinstall` and `--build-from-source` to ensure an actual build including the userimg file.
